### PR TITLE
Add flags `subdirectory_recursion` and `ignore_dependency`

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,14 @@ Add reviewers to the pull requests created by the GitHub Action. Multiple review
 
 By default, the GitHub Action scans the entire repository by looking for `project.clj` and `deps.edn` files. It is possible to define a specific sub-path to not scan the entire repository.
 
+### subdirectory_recursion
+
+Boolean value to enable the iterative search for `project.clj` and `deps.edn` files in subdirectories. The default value is `true`. 
+
+### ignore_dependency
+
+Add dependencies (`[groupId]/[artifactId]`) that must not be updated. Dependencies need to be separated by a comma (`,`).
+
 ## Security
 
 If you find a security vulnerability, please report it privately at security@pitch.com.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Add reviewers to the pull requests created by the GitHub Action. Multiple review
 
 By default, the GitHub Action scans the entire repository by looking for `project.clj` and `deps.edn` files. It is possible to define a specific sub-path to not scan the entire repository.
 
-### subdirectory_recursion
+### include_subdirectories
 
 Boolean value to enable the iterative search for `project.clj` and `deps.edn` files in subdirectories. The default value is `true`. 
 

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ inputs:
     description: 'Directory which will be scanned.'
     required: false
     default: ''
-  subdirectory_recursion:
+  include_subdirectories:
     description: 'Iteratively look for project.clj and deps.edn in the subdirectories.'
     required: false
     default: true

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,14 @@ inputs:
     description: 'Directory which will be scanned.'
     required: false
     default: ''
+  subdirectory_recursion:
+    description: 'Iteratively look for project.clj and deps.edn in the subdirectories.'
+    required: false
+    default: true
+  ignore_dependency:
+    description: 'Ignore specific dependencies. Separate items by comma.'
+    required: false
+    default: ''
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/antq.sh
+++ b/antq.sh
@@ -73,7 +73,7 @@ mapfile -t array < <(find . -name "$1")
 if [[ $1 == "project.clj" ]]; then
     echo "## Outdated Dependencies" >> "$GITHUB_STEP_SUMMARY"
 fi
-if [[ $INPUT_SUBDIRECTORY_RECURSION != true ]]; then
+if [[ $INPUT_INCLUDE_SUBDIRECTORIES != true ]]; then
     if [[ $1 == "project.clj" ]] && [[ "${array[*]}" == *"./project.clj"* ]]; then
         array=("./project.clj")
     elif [[ $1 == "deps.edn" ]] && [[ "${array[*]}" == *"./deps.edn"* ]]; then

--- a/antq.sh
+++ b/antq.sh
@@ -73,6 +73,15 @@ mapfile -t array < <(find . -name "$1")
 if [[ $1 == "project.clj" ]]; then
     echo "## Outdated Dependencies" >> "$GITHUB_STEP_SUMMARY"
 fi
+if [[ $INPUT_SUBDIRECTORY_RECURSION != true ]]; then
+    if [[ $1 == "project.clj" ]] && [[ "${array[*]}" == *"./project.clj"* ]]; then
+        array=("./project.clj")
+    elif [[ $1 == "deps.edn" ]] && [[ "${array[*]}" == *"./deps.edn"* ]]; then
+        array=("./deps.edn")
+    else
+        array=()
+    fi
+fi
 for i in "${array[@]}"
 do
     summaryOutput=0
@@ -153,7 +162,7 @@ do
                 fi
                 counterDuplicate+="| $name | $version | $latestVersion | [🔗 Changelog]($changesUrl) | $securityUpdate |"
             fi
-            if [[ $INPUT_AUTO_PULL_REQUEST == true ]]; then
+            if [[ $INPUT_AUTO_PULL_REQUEST == true ]] && [[ ! "$INPUT_IGNORE_DEPENDENCY" == *"$name"* ]]; then
                 vulnerability_fix_pr "${newDependencies[@]}"
                 if [[ $INPUT_SECURITY_UPDATES_ONLY == true ]]; then
                     if [ -n "$securityUpdate" ]; then

--- a/scanner.sh
+++ b/scanner.sh
@@ -73,7 +73,7 @@ mapfile -t array < <(find . -name "$1")
 if [[ $1 == "project.clj" ]]; then
   echo "## Dependency Tree" >> "$GITHUB_STEP_SUMMARY"
 fi
-if [[ $INPUT_SUBDIRECTORY_RECURSION != true ]]; then
+if [[ $INPUT_INCLUDE_SUBDIRECTORIES != true ]]; then
     if [[ $1 == "project.clj" ]] && [[ "${array[*]}" == *"./project.clj"* ]]; then
         array=("./project.clj")
     elif [[ $1 == "deps.edn" ]] && [[ "${array[*]}" == *"./deps.edn"* ]]; then

--- a/scanner.sh
+++ b/scanner.sh
@@ -73,6 +73,15 @@ mapfile -t array < <(find . -name "$1")
 if [[ $1 == "project.clj" ]]; then
   echo "## Dependency Tree" >> "$GITHUB_STEP_SUMMARY"
 fi
+if [[ $INPUT_SUBDIRECTORY_RECURSION != true ]]; then
+    if [[ $1 == "project.clj" ]] && [[ "${array[*]}" == *"./project.clj"* ]]; then
+        array=("./project.clj")
+    elif [[ $1 == "deps.edn" ]] && [[ "${array[*]}" == *"./deps.edn"* ]]; then
+        array=("./deps.edn")
+    else
+        array=()
+    fi
+fi
 for i in "${array[@]}"
 do
     i=${i/.}


### PR DESCRIPTION
This PR adds two new fields (flags) in `action.yml`: `subdirectory_recursion` and `ignore_dependency`. These flags should help to design more granular workflows, especially in monorepos.

**Example**

```
# Search for `project.clj` and `deps.edn` only in the repo's
# main folder. No subfolders.
uses: pitch-io/clojure-dependabot@main
with:
  auto_pull_request: false
  subdirectory_recursion: false

# Search for `project.clj` and `deps.edn` in `/test/foo` and subfolders
# but don't update the dependency `foo.bar/foo-bar`.
uses: pitch-io/clojure-dependabot@main
with:
  directory: '/test/foo'
  ignore_dependency: 'foo.bar/foo-bar'
```