### PR TITLE
Set `github-actions` (bot) as PR author

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,10 @@ RUN apt update && \
 
 COPY scanner.sh /scanner.sh
 
+COPY dependabot_alerts.sh /dependabot_alerts.sh
+
+COPY alerts_summary.sh /alerts_summary.sh
+
 COPY antq.sh /antq.sh
 
 COPY entrypoint.sh /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This GitHub Action looks for all `project.clj` and `deps.edn` in the repository 
 
 ## Required Tokens
 
-The Action requires the following environment variables to run the [maven-dependency-submission-action](https://github.com/advanced-security/maven-dependency-submission-action) CLI and GitHub CLI to list GitHub Security Alerts (GHSA) and to create auto-pull-requests for dependencies updates.
+The Action requires the following environment variables to run the [maven-dependency-submission-action](https://github.com/advanced-security/maven-dependency-submission-action) CLI and GitHub CLI to list GitHub Security Alerts (GHSA) and to create auto-pull-requests for dependencies updates. Both a Personal Access Token (PAT) and GitHub Token (`github.token`) are required: the Action needs a PAT because GitHub Token cannot be used to list security alerts for security reasons ([_"Granting access to security alerts"_](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-security-and-analysis-settings-for-your-repository#granting-access-to-security-alerts)), and the Action cannot open pull-requests as `github-actions (bot)` if it doesn't use the GitHub Token.
 
 
 - GitHub Personal Access Token to run GitHub CLI (recommended privileges: `repo:all`)

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The Action requires the following environment variables to run the [maven-depend
 
 
 - GitHub Personal Access Token to run GitHub CLI (recommended privileges: `repo:all`)
+- `github.token`
 - `github.repository`
 - `github.ref`
 - `github.sha`
@@ -26,7 +27,8 @@ on:
   workflow_dispatch:
 
 env:
-  GITHUB_TOKEN: ${{ secret.PAT }}
+  GITHUB_PAT: ${{ secret.PAT }}
+  GITHUB_TOKEN: ${{ github.token }}
   GITHUB_REPOSITORY: ${{ github.repository }}
   GITHUB_REF: ${{ github.ref }}
   GITHUB_SHA: ${{ github.sha }}

--- a/alerts_summary.sh
+++ b/alerts_summary.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+
+dependency_tree_summary () {
+    mvn dependency:tree -Dverbose=true -DoutputFile="${1}/dependency-tree.txt"
+    {
+        echo "### $INPUT_DIRECTORY$2"
+        echo "<details>"
+        echo ""
+        echo "\`\`\`"
+        cat "${1}/dependency-tree.txt"
+        echo "\`\`\`"
+        echo "</details>"
+        echo ""
+    } >> "$GITHUB_STEP_SUMMARY"
+}
+
+vulnerabilities_summary () {
+    mapfile -t info_pack < <(jq -r --arg MANIFEST "$1" '.[] | select(.dependency.manifest_path == $MANIFEST and .state == "open") | (.number|tostring) + "|" + .security_vulnerability.package.name + "|" + .security_vulnerability.severity + "|" + .security_advisory.ghsa_id + "|" + .security_advisory.cve_id + "|" + .security_vulnerability.first_patched_version.identifier + "|"' <<< "$2")
+    for i in "${info_pack[@]}"
+    do
+        IFS='|' read -r -a array_i <<< "$i" 
+        cd "/${1/'pom.xml'/''}" || exit
+        dep_level=$(mvn dependency:tree -DoutputType=dot -Dincludes="${array_i[1]}" | grep -e "->" | cut -d ">" -f 2 | cut -d '"' -f 2 | cut -d ":" -f 1-2)
+        IFS=' ' read -r -a dependency_level <<< "$dep_level"
+        array_i+=("${dependency_level[0]}")
+        table_row="| "
+        counter=0
+        for j in "${array_i[@]}"
+        do
+            if [[ $counter == 0 ]]; then
+                table_row+="[$j](https://github.com/$GITHUB_REPOSITORY/security/dependabot/$j) | "
+                counter=$((counter+1))
+            elif [[ $counter == 1 ]]; then
+                table_row+="$j | "
+                counter=$((counter+1))
+            elif [[ $counter == 2 ]]; then
+                if [[ $j == "critical" ]] || [[ $j == "high" ]]; then
+                    table_row+="‼️ $j | "
+                else
+                    table_row+="$j | "
+                fi
+                counter=$((counter+1))
+            elif [[ $counter == 3 ]]; then
+                table_row+="$j | "
+                counter=$((counter+1))
+            elif [[ $counter == 4 ]]; then
+                if [[ $j = "null" ]]; then
+                    table_row+="  | "
+                else
+                    table_row+="$j | "
+                fi
+                counter=$((counter+1))
+            elif [[ $counter == 5 ]]; then
+                table_row+="$j | "
+                counter=$((counter+1))
+            elif [[ $counter == 6 ]]; then
+                table_row+="$j | "
+                counter=$((counter+1))
+            else
+                continue
+            fi
+        done
+        echo "$table_row" >> "$GITHUB_STEP_SUMMARY"
+    done
+}
+
+
+# $1 - "project.clj" or "deps.edn"
+if [[ -n $INPUT_DIRECTORY ]]; then
+    cd "$GITHUB_WORKSPACE$INPUT_DIRECTORY" || exit
+fi
+mapfile -t array < <(find . -name "$1")
+if [[ $1 == "project.clj" ]]; then
+  echo "## Dependency Tree" >> "$GITHUB_STEP_SUMMARY"
+fi
+if [[ $INPUT_INCLUDE_SUBDIRECTORIES != true ]]; then
+    if [[ $1 == "project.clj" ]] && [[ "${array[*]}" == *"./project.clj"* ]]; then
+        array=("./project.clj")
+    elif [[ $1 == "deps.edn" ]] && [[ "${array[*]}" == *"./deps.edn"* ]]; then
+        array=("./deps.edn")
+    else
+        array=()
+    fi
+fi
+vul_page=$(cat /tmp/dependabot_alerts.json)
+for i in "${array[@]}"
+do
+    i=${i/.}
+    cljdir=$GITHUB_WORKSPACE$INPUT_DIRECTORY${i//\/$1}
+    cd "$cljdir" || exit
+    if  [[ $1 == "project.clj" ]]; then
+        dependency_tree_summary "projectclj" "$i"
+        rm pom.xml
+        db_path="${cljdir}/projectclj/pom.xml"
+        db_path=${db_path:1}
+        {
+            echo "| Number | Package | Severity | GHSA | CVE | Patched in | Dependency level |"
+            echo "| --- | --- | --- | --- | --- | --- | --- |"
+        } >> "$GITHUB_STEP_SUMMARY"
+        vulnerabilities_summary "$db_path" "$vul_page"
+        echo "" >> "$GITHUB_STEP_SUMMARY"
+    else
+        dependency_tree_summary "depsedn" "$i"
+        rm pom.xml
+        db_path="${cljdir}/depsedn/pom.xml"
+        db_path=${db_path:1}
+        {
+            echo "| Number | Package | Severity | GHSA | CVE | Patched in | Dependency level |"
+            echo "| --- | --- | --- | --- | --- | --- | --- |"
+        } >> "$GITHUB_STEP_SUMMARY"
+        vulnerabilities_summary "$db_path" "$vul_page"
+        echo "" >> "$GITHUB_STEP_SUMMARY"
+    fi
+done

--- a/antq.sh
+++ b/antq.sh
@@ -130,7 +130,7 @@ do
     length=$(jq '. | length' /tmp/antq-report.json)
     length=$((length-1))
     githubAlerts=()
-    vul_page=$(gh api -H "Accept: application/vnd.github+json" "/repos/$GITHUB_REPOSITORY/dependabot/alerts" --paginate)
+    vul_page=$(cat /tmp/dependabot_alerts.json)
     if  [[ $1 == "project.clj" ]]; then
         pomManifestPath="$cljdir/projectclj" || exit
     else

--- a/dependabot_alerts.sh
+++ b/dependabot_alerts.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+export GITHUB_TOKEN=$GITHUB_PAT
+sleep 5
+gh api -H "Accept: application/vnd.github+json" "/repos/$GITHUB_REPOSITORY/dependabot/alerts" --paginate > /tmp/dependabot_alerts.json || true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,6 +8,11 @@ git config --global user.name "github-actions[bot]"
 chmod +x /scanner.sh
 /scanner.sh project.clj
 /scanner.sh deps.edn
+chmod +x /dependabot_alerts.sh
+/dependabot_alerts.sh
+chmod +x /alerts_summary.sh
+/alerts_summary.sh project.clj
+/alerts_summary.sh deps.edn
 chmod +x /antq.sh
 /antq.sh project.clj
 /antq.sh deps.edn

--- a/scanner.sh
+++ b/scanner.sh
@@ -1,78 +1,10 @@
 #!/bin/bash
 
-dependency_tree_summary () {
-    mvn dependency:tree -Dverbose=true -DoutputFile="${1}/dependency-tree.txt"
-    {
-        echo "### $INPUT_DIRECTORY$2"
-        echo "<details>"
-        echo ""
-        echo "\`\`\`"
-        cat "${1}/dependency-tree.txt"
-        echo "\`\`\`"
-        echo "</details>"
-        echo ""
-    } >> "$GITHUB_STEP_SUMMARY"
-}
-
-vulnerabilities_summary () {
-    mapfile -t info_pack < <(jq -r --arg MANIFEST "$1" '.[] | select(.dependency.manifest_path == $MANIFEST and .state == "open") | (.number|tostring) + "|" + .security_vulnerability.package.name + "|" + .security_vulnerability.severity + "|" + .security_advisory.ghsa_id + "|" + .security_advisory.cve_id + "|" + .security_vulnerability.first_patched_version.identifier + "|"' <<< "$2")
-    for i in "${info_pack[@]}"
-    do
-        IFS='|' read -r -a array_i <<< "$i" 
-        cd "/${1/'pom.xml'/''}" || exit
-        dep_level=$(mvn dependency:tree -DoutputType=dot -Dincludes="${array_i[1]}" | grep -e "->" | cut -d ">" -f 2 | cut -d '"' -f 2 | cut -d ":" -f 1-2)
-        IFS=' ' read -r -a dependency_level <<< "$dep_level"
-        array_i+=("${dependency_level[0]}")
-        table_row="| "
-        counter=0
-        for j in "${array_i[@]}"
-        do
-            if [[ $counter == 0 ]]; then
-                table_row+="[$j](https://github.com/$GITHUB_REPOSITORY/security/dependabot/$j) | "
-                counter=$((counter+1))
-            elif [[ $counter == 1 ]]; then
-                table_row+="$j | "
-                counter=$((counter+1))
-            elif [[ $counter == 2 ]]; then
-                if [[ $j == "critical" ]] || [[ $j == "high" ]]; then
-                    table_row+="‼️ $j | "
-                else
-                    table_row+="$j | "
-                fi
-                counter=$((counter+1))
-            elif [[ $counter == 3 ]]; then
-                table_row+="$j | "
-                counter=$((counter+1))
-            elif [[ $counter == 4 ]]; then
-                if [[ $j = "null" ]]; then
-                    table_row+="  | "
-                else
-                    table_row+="$j | "
-                fi
-                counter=$((counter+1))
-            elif [[ $counter == 5 ]]; then
-                table_row+="$j | "
-                counter=$((counter+1))
-            elif [[ $counter == 6 ]]; then
-                table_row+="$j | "
-                counter=$((counter+1))
-            else
-                continue
-            fi
-        done
-        echo "$table_row" >> "$GITHUB_STEP_SUMMARY"
-    done
-}
-
-
 # $1 - "project.clj" or "deps.edn"
 if [[ -n $INPUT_DIRECTORY ]]; then
     cd "$GITHUB_WORKSPACE$INPUT_DIRECTORY" || exit
 fi
 mapfile -t array < <(find . -name "$1")
-if [[ $1 == "project.clj" ]]; then
-  echo "## Dependency Tree" >> "$GITHUB_STEP_SUMMARY"
-fi
 if [[ $INPUT_INCLUDE_SUBDIRECTORIES != true ]]; then
     if [[ $1 == "project.clj" ]] && [[ "${array[*]}" == *"./project.clj"* ]]; then
         array=("./project.clj")
@@ -97,36 +29,5 @@ do
         mkdir depsedn
         cp pom.xml depsedn/
         maven-dependency-submission-linux-x64 --token "$GITHUB_TOKEN" --repository "$GITHUB_REPOSITORY" --branch-ref "$GITHUB_REF" --sha "$GITHUB_SHA" --directory "${cljdir}/depsedn" --job-name "${INPUT_DIRECTORY}${i}/depsedn"
-    fi
-done
-gh auth login --with-token <<<"$GITHUB_TOKEN"
-vul_page=$(gh api -H "Accept: application/vnd.github+json" "/repos/$GITHUB_REPOSITORY/dependabot/alerts" --paginate)
-for i in "${array[@]}"
-do
-    i=${i/.}
-    cljdir=$GITHUB_WORKSPACE$INPUT_DIRECTORY${i//\/$1}
-    cd "$cljdir" || exit
-    if  [[ $1 == "project.clj" ]]; then
-        dependency_tree_summary "projectclj" "$i"
-        rm pom.xml
-        db_path="${cljdir}/projectclj/pom.xml"
-        db_path=${db_path:1}
-        {
-            echo "| Number | Package | Severity | GHSA | CVE | Patched in | Dependency level |"
-            echo "| --- | --- | --- | --- | --- | --- | --- |"
-        } >> "$GITHUB_STEP_SUMMARY"
-        vulnerabilities_summary "$db_path" "$vul_page"
-        echo "" >> "$GITHUB_STEP_SUMMARY"
-    else
-        dependency_tree_summary "depsedn" "$i"
-        rm pom.xml
-        db_path="${cljdir}/depsedn/pom.xml"
-        db_path=${db_path:1}
-        {
-            echo "| Number | Package | Severity | GHSA | CVE | Patched in | Dependency level |"
-            echo "| --- | --- | --- | --- | --- | --- | --- |"
-        } >> "$GITHUB_STEP_SUMMARY"
-        vulnerabilities_summary "$db_path" "$vul_page"
-        echo "" >> "$GITHUB_STEP_SUMMARY"
     fi
 done


### PR DESCRIPTION
This PR sets **github-actions** (bot) as the author of the pull-requests opened by the GitHub Actions. It is still possible to have the PAT's owner as the author by setting the same PAT token for both the env variables `GITHUB_TOKEN` and `GITHUB_PAT`.

PRs created by a GitHub Action (**github-actions** (bot)) have [some security restrictions](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#workarounds-to-trigger-further-workflow-runs) that can impact repository CI. 