### PR TITLE
Fix `pom.xml` conflict when `deps.edn` are `project.clj` are in the same folder

### DIFF
--- a/alerts_summary.sh
+++ b/alerts_summary.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 dependency_tree_summary () {
-    mvn dependency:tree -Dverbose=true -DoutputFile="${1}/dependency-tree.txt"
+    mvn dependency:tree -Dverbose=true -DoutputFile="dependency-tree.txt"
     {
         echo "### $INPUT_DIRECTORY$2"
         echo "<details>"
         echo ""
         echo "\`\`\`"
-        cat "${1}/dependency-tree.txt"
+        cat dependency-tree.txt
         echo "\`\`\`"
         echo "</details>"
         echo ""
@@ -87,10 +87,9 @@ for i in "${array[@]}"
 do
     i=${i/.}
     cljdir=$GITHUB_WORKSPACE$INPUT_DIRECTORY${i//\/$1}
-    cd "$cljdir" || exit
     if  [[ $1 == "project.clj" ]]; then
-        dependency_tree_summary "projectclj" "$i"
-        rm pom.xml
+        cd "${cljdir}/projectclj" || exit
+        dependency_tree_summary "$i"
         db_path="${cljdir}/projectclj/pom.xml"
         db_path=${db_path:1}
         {
@@ -100,8 +99,8 @@ do
         vulnerabilities_summary "$db_path" "$vul_page"
         echo "" >> "$GITHUB_STEP_SUMMARY"
     else
-        dependency_tree_summary "depsedn" "$i"
-        rm pom.xml
+        cd "${cljdir}/depsedn" || exit
+        dependency_tree_summary "$i"
         db_path="${cljdir}/depsedn/pom.xml"
         db_path=${db_path:1}
         {

--- a/dependabot_alerts.sh
+++ b/dependabot_alerts.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 export GITHUB_TOKEN=$GITHUB_PAT
-sleep 5
+sleep 10
 gh api -H "Accept: application/vnd.github+json" "/repos/$GITHUB_REPOSITORY/dependabot/alerts" --paginate > /tmp/dependabot_alerts.json || true

--- a/scanner.sh
+++ b/scanner.sh
@@ -22,12 +22,12 @@ do
     if  [[ $1 == "project.clj" ]]; then
         lein pom
         mkdir projectclj
-        cp pom.xml projectclj/
+        mv pom.xml projectclj/
         maven-dependency-submission-linux-x64 --token "$GITHUB_TOKEN" --repository "$GITHUB_REPOSITORY" --branch-ref "$GITHUB_REF" --sha "$GITHUB_SHA" --directory "${cljdir}/projectclj" --job-name "${INPUT_DIRECTORY}${i}/projectclj"
     else
         clojure -Spom
         mkdir depsedn
-        cp pom.xml depsedn/
+        mv pom.xml depsedn/
         maven-dependency-submission-linux-x64 --token "$GITHUB_TOKEN" --repository "$GITHUB_REPOSITORY" --branch-ref "$GITHUB_REF" --sha "$GITHUB_SHA" --directory "${cljdir}/depsedn" --job-name "${INPUT_DIRECTORY}${i}/depsedn"
     fi
 done


### PR DESCRIPTION
This PR fixes a bug introduced in the last PR (https://github.com/pitch-io/clojure-dependabot/pull/12). The last PR split `scanner.sh` into other two bash files, but - due to the current structure of `entrypoint.sh` -  this introduced a conflict for the generated `pom.xml` files, when a `deps.edn` and `project.clj` are in the same folder. 