### PR TITLE
Fix `maven-dependency-submission-linux`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt update && \
     curl -O https://download.clojure.org/install/linux-install-1.11.1.1165.sh && \
     chmod +x linux-install-1.11.1.1165.sh && \
     ./linux-install-1.11.1.1165.sh && \
-    curl -L -o maven-dependency-submission-linux-x64 https://github.com/advanced-security/maven-dependency-submission-action/raw/2ecce44ccb44fd4b52f43468d3644e2d3e2b3cf2/cli/maven-dependency-submission-linux-x64 && \
+    curl --retry 5 --retry-max-time 120 --fail-with-body -L -o maven-dependency-submission-linux-x64 https://github.com/advanced-security/maven-dependency-submission-action/raw/2ecce44ccb44fd4b52f43468d3644e2d3e2b3cf2/cli/maven-dependency-submission-linux-x64 && \
     chmod +x maven-dependency-submission-linux-x64 && \
     mv maven-dependency-submission-linux-x64 /usr/bin/maven-dependency-submission-linux-x64 && \
     clojure -Ttools install-latest :lib com.github.liquidz/antq :as antq && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,15 +10,16 @@ RUN apt update && \
     curl -O https://download.clojure.org/install/linux-install-1.11.1.1165.sh && \
     chmod +x linux-install-1.11.1.1165.sh && \
     ./linux-install-1.11.1.1165.sh && \
-    curl -L -o maven-dependency-submission-linux-x64 https://github.com/advanced-security/maven-dependency-submission-action/raw/main/cli/maven-dependency-submission-linux-x64 && \
-    chmod +x maven-dependency-submission-linux-x64 && \
-    mv maven-dependency-submission-linux-x64 /usr/bin/maven-dependency-submission-linux-x64 && \
     clojure -Ttools install-latest :lib com.github.liquidz/antq :as antq && \
     curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \
     chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg && \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
     apt update && \
     apt install gh -y
+
+# maven-dependency-submission-linux-x64 2.0.1
+# commit: 2ecce44ccb44fd4b52f43468d3644e2d3e2b3cf2
+COPY maven-dependency-submission-linux /maven-dependency-submission-linux
 
 COPY scanner.sh /scanner.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,23 +3,22 @@ FROM clojure:lein-slim-bullseye
 LABEL com.github.actions.name="Dependabot for Clojure projects" \
       com.github.actions.description="Run Dependabot as GitHub Action workflow in your Clojure project."
 
-# Install maven, antq, maven-dependency-submission cli, clojure, and gh cli
+# Install maven, antq, maven-dependency-submission cli 2.0.1, clojure, and gh cli
 RUN apt update && \
     apt install maven libmaven-dependency-plugin-java curl jq git build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libsqlite3-dev libreadline-dev libffi-dev libbz2-dev -y && \
     rm -rf /var/lib/apt/lists/* && \
     curl -O https://download.clojure.org/install/linux-install-1.11.1.1165.sh && \
     chmod +x linux-install-1.11.1.1165.sh && \
     ./linux-install-1.11.1.1165.sh && \
+    curl -L -o maven-dependency-submission-linux-x64 https://github.com/advanced-security/maven-dependency-submission-action/raw/2ecce44ccb44fd4b52f43468d3644e2d3e2b3cf2/cli/maven-dependency-submission-linux-x64 && \
+    chmod +x maven-dependency-submission-linux-x64 && \
+    mv maven-dependency-submission-linux-x64 /usr/bin/maven-dependency-submission-linux-x64 && \
     clojure -Ttools install-latest :lib com.github.liquidz/antq :as antq && \
     curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \
     chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg && \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
     apt update && \
     apt install gh -y
-
-# maven-dependency-submission-linux-x64 2.0.1
-# commit: 2ecce44ccb44fd4b52f43468d3644e2d3e2b3cf2
-COPY maven-dependency-submission-linux /maven-dependency-submission-linux
 
 COPY scanner.sh /scanner.sh
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 set -e
 
+# https://github.com/advanced-security/maven-dependency-submission-action/commit/2ecce44ccb44fd4b52f43468d3644e2d3e2b3cf2
+chmod +x /maven-dependency-submission-linux
+mv /maven-dependency-submission-linux /usr/bin/maven-dependency-submission-linux-x64
 # Unsafe decision to fix https://github.com/actions/runner/issues/2033
 git config --global --add safe.directory "$GITHUB_WORKSPACE"
 git config --global user.email "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,6 @@
 #!/bin/sh
 set -e
 
-# https://github.com/advanced-security/maven-dependency-submission-action/commit/2ecce44ccb44fd4b52f43468d3644e2d3e2b3cf2
-chmod +x /maven-dependency-submission-linux
-mv /maven-dependency-submission-linux /usr/bin/maven-dependency-submission-linux-x64
 # Unsafe decision to fix https://github.com/actions/runner/issues/2033
 git config --global --add safe.directory "$GITHUB_WORKSPACE"
 git config --global user.email "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"


### PR DESCRIPTION
The last changes in [advanced-security/maven-dependency-submission-action](https://github.com/advanced-security/maven-dependency-submission-action/commit/72bdd87d620be905d2add3aa48214250a1921eb3) have broken the GitHub Action, and in addition the last version of maven-dependency-submission CLI (3.0.0) doesn't seem work properly using the same commands (the flag `-b` returns the error `Branch reference must be in path form, e.g. 'refs/heads/main' for the 'main' branch.`). 

This PR imports the binary file of maven-dependency-submission 2.0.1 which seems to work properly. 