### PR TITLE
Remove flag `--fail-with-body` from `curl` command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt update && \
     curl -O https://download.clojure.org/install/linux-install-1.11.1.1165.sh && \
     chmod +x linux-install-1.11.1.1165.sh && \
     ./linux-install-1.11.1.1165.sh && \
-    curl --retry 5 --retry-max-time 120 --fail-with-body -L -o maven-dependency-submission-linux-x64 https://github.com/advanced-security/maven-dependency-submission-action/raw/2ecce44ccb44fd4b52f43468d3644e2d3e2b3cf2/cli/maven-dependency-submission-linux-x64 && \
+    curl --retry 5 --retry-max-time 120 -L -o maven-dependency-submission-linux-x64 https://github.com/advanced-security/maven-dependency-submission-action/raw/2ecce44ccb44fd4b52f43468d3644e2d3e2b3cf2/cli/maven-dependency-submission-linux-x64 && \
     chmod +x maven-dependency-submission-linux-x64 && \
     mv maven-dependency-submission-linux-x64 /usr/bin/maven-dependency-submission-linux-x64 && \
     clojure -Ttools install-latest :lib com.github.liquidz/antq :as antq && \


### PR DESCRIPTION
The docker image is a Debian one, and its cURL version doesn't support `--fail-with-body`.