### PR TITLE
Improve `update_omitted` output

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ jobs:
 | --- | --- |
 | `auto_pull_request` | Boolean value to enable or disable auto-pull-requests for dependencies updates. |
 | `security_updates_only`| Boolean value to enable only security updates. |
-| `update_omitted` | Update omitted packages. |
+| `update_omitted` | Update omitted packages. Unstable feature. |
 | `severity` | Minimum severity to update vulnerable dependencies. The values are `low`, `medium`, `high`, and `critical`. The default value is `low`. |
 | `main_branch` | The branch into which you want the pull requests created by the GitHub Action merged. |
 | `labels` | Add labels to the pull requests created by the GitHub Action. The labels need to be separated by a comma (`,`) and need to already exist. |

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
     required: false
     default: true
   update_omitted:
-    descrition: 'Update omitted packages.'
+    descrition: '[Unstable] Update omitted packages.'
     required: false
     default: false
   severity:


### PR DESCRIPTION
Line 105 in `antq.sh` leads to false-positive pull-requests for packages that don't require a security update, if `update_omitted` is set to `true`. This PR adds more conditions to reduce the likelihood of false positives, but it doesn't catch all the scenarios (e.g. if the maintainers downgrade a package version, etc).

```
if (version_ge "${AfterUpdateVersions[$jj]}" "${array_alertGh[3]}" && [[ ! "${newDependencies[*]}" == *"${array_alertGh[0]}|${AfterUpdateVersions[$jj]}|"* ]]); then
```