### PR TITLE
Auto-close outdated Dependabot PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ jobs:
 | `ignore_dependency` | Add dependencies (`[groupId]/[artifactId]`) that must not be updated. Dependencies need to be separated by a comma (`,`). |
 | `allow_dependency` | Add dependencies (`[groupId]/[artifactId]`) that must be updated. Dependencies need to be separated by a comma (`,`). If a dependency is matched by an `allow_dependency` and an `ignore_dependency` statement, **then it is ignored.** |
 | `local_dependency` | Install dependencies (`[pathToFile]:[groupdId]:[artifactId]:[version]:[packaging]`) into local repository cache. Dependencies need to be separated by a comma (`,`). |
+| `summary` | Boolean. Print a markdown summary when the GitHub Workflow ends. |
 | `verbose` | Boolean. Enable verbose mode. |
 
 

--- a/action.yml
+++ b/action.yml
@@ -54,11 +54,11 @@ inputs:
     required: false
     default: ''
   summary:
-    descrition: 'Print a human-friendly workflow summary.'
+    description: 'Print a human-friendly workflow summary.'
     required: false
     default: true
   verbose:
-    descrition: 'Verbose output.'
+    description: 'Verbose output.'
     required: false
     default: false
 runs:

--- a/action.yml
+++ b/action.yml
@@ -53,6 +53,10 @@ inputs:
     description: 'Install maven jars to the local repository cache. Separate items by comma.'
     required: false
     default: ''
+  summary:
+    descrition: 'Print a human-friendly workflow summary.'
+    required: false
+    default: true
   verbose:
     descrition: 'Verbose output.'
     required: false

--- a/antq.sh
+++ b/antq.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-update_package () {
+update_package() {
     if [[ $3 == "project.clj" ]]; then
         clojure -Sdeps '{:deps {com.github.liquidz/antq {:mvn/version "RELEASE"}}}' -M -m antq.core --upgrade --force --directory "$1" --focus="$2" --skip=clojure-cli
     else
@@ -25,6 +25,36 @@ version_ge() {
 }
 version_gt() { 
     test "$(echo "$@" | tr " " "\n" | sort -V | head -n 1)" != "$1"; 
+}
+version_lt() { 
+    test "$(echo "$@" | tr " " "\n" | sort -V | head -n 1)" == "$1"; 
+}
+
+# Define the function to close outdated PRs when a new update is available
+close_outdated_pr() {
+    existingPrs=$(gh pr list --state open --json title,number | jq -c '.[]')
+    if [[ "$INPUT_VERBOSE" == true ]]; then
+        echo "Existing PRs: ${existingPrs}"
+    fi
+    
+    # Use process substitution to pass the JSON objects directly to the while loop
+    while IFS= read -r pr; do
+        prTitle=$(echo "$pr" | jq -r '.title')
+        prNumber=$(echo "$pr" | jq -r '.number')
+        if [[ "$INPUT_VERBOSE" == true ]]; then
+            echo "Title: ${prTitle}"
+            echo "Number: ${prNumber}"
+        fi
+        if [[ "$prTitle" == *"Bump $1 from"* ]] && [[ "$prTitle" == *"$2"* ]]; then
+            outdatedVersion=$(echo "$prTitle" | awk '{print $6}')
+            if [[ "$outdatedVersion" != "" ]] && version_lt "$outdatedVersion" "$3"; then
+                if [[ "$INPUT_VERBOSE" == true ]]; then
+                    echo "Closing outdated PR #$prNumber: $prTitle"
+                fi
+                gh pr close "$prNumber" --comment "Closing this PR as a newer update to version $3 is available."
+            fi
+        fi
+    done < <(echo "$existingPrs")
 }
 
 high_critical_check_security_fix () {
@@ -273,7 +303,7 @@ if [[ "$INPUT_VERBOSE" == true ]]; then
         echo "Finding all $1 files"
 fi
 mapfile -t array < <(find . -name "$1")
-if [[ $1 == "project.clj" ]]; then
+if [[ $1 == "project.clj" ]] && [[ "$INPUT_SUMMARY" == true ]]; then
     echo "## Outdated Dependencies" >> "$GITHUB_STEP_SUMMARY"
 fi
 if [[ $INPUT_INCLUDE_SUBDIRECTORIES != true ]]; then
@@ -298,6 +328,8 @@ do
     if [[ "$INPUT_VERBOSE" == true ]]; then
         echo "Creating antq-report.json"
     fi
+    # -P helps to avoid concurrency errors
+    clojure -Sdeps '{:deps {com.github.liquidz/antq {:mvn/version "RELEASE"}}}' -P
     clojure -Sdeps '{:deps {com.github.liquidz/antq {:mvn/version "RELEASE"}}}' -M -m antq.core --reporter="json" > /tmp/antq-report.json || true
     length=$(jq '. | length' /tmp/antq-report.json)
     length=$((length-1))
@@ -384,7 +416,7 @@ do
                 securityUpdate="⬆️"
             fi
             prefix="dependabot/clojure${cljdir/$GITHUB_WORKSPACE}/$escapedName-$latestVersion-$1-"
-            if [[ "$summaryOutput" -eq 0 ]]; then
+            if [[ "$summaryOutput" -eq 0 ]] && [[ "$INPUT_SUMMARY" == true ]]; then
                 {
                     echo "### $INPUT_DIRECTORY$i"
                     echo "<details>"
@@ -397,7 +429,7 @@ do
             if [[ "$INPUT_VERBOSE" == true ]]; then
                 echo "Adding info to GitHub Summary"
             fi            
-            if [[ $counterDuplicate != *"| $name | $version | $latestVersion | [🔗 Changelog]($changesUrl) | $securityUpdate |"* ]]; then
+            if [[ $counterDuplicate != *"| $name | $version | $latestVersion | [🔗 Changelog]($changesUrl) | $securityUpdate |"* ]] && [[ "$INPUT_SUMMARY" == true ]]; then
                 if [[ $changesUrl == "null" ]]; then
                     echo "| $name | $version | $latestVersion |  | $securityUpdate |" >> "$GITHUB_STEP_SUMMARY"
                     if [[ "$INPUT_VERBOSE" == true ]]; then
@@ -436,6 +468,7 @@ do
                                     if [[ "$INPUT_VERBOSE" == true ]]; then
                                         echo "Create the security PR dependabot/clojure${cljdir/$GITHUB_WORKSPACE}/$escapedName-$latestVersion-$1-$time"
                                     fi
+                                    close_outdated_pr "$name" "$version" "$latestVersion"
                                     update_package "$cljdir" "$name" "$1" "$escapedName" "$latestVersion" "$time" "$version" "$changesUrl" "$securityUpdatesPrBody"
                                 else
                                     git checkout "$INPUT_MAIN_BRANCH"
@@ -444,6 +477,7 @@ do
                                 if [[ "$INPUT_VERBOSE" == true ]]; then
                                     echo "Create the security PR dependabot/clojure${cljdir/$GITHUB_WORKSPACE}/$escapedName-$latestVersion-$1-$time"
                                 fi
+                                close_outdated_pr "$name" "$version" "$latestVersion"
                                 update_package "$cljdir" "$name" "$1" "$escapedName" "$latestVersion" "$time" "$version" "$changesUrl" "$securityUpdatesPrBody"
                             fi    
                         fi
@@ -465,6 +499,7 @@ do
                                 if [[ "$INPUT_VERBOSE" == true ]]; then
                                     echo "Create the security PR dependabot/clojure${cljdir/$GITHUB_WORKSPACE}/$escapedName-$latestVersion-$1-$time"
                                 fi
+                                close_outdated_pr "$name" "$version" "$latestVersion"
                                 update_package "$cljdir" "$name" "$1" "$escapedName" "$latestVersion" "$time" "$version" "$changesUrl" "$securityUpdatesPrBody"
                             else
                                 git checkout "$INPUT_MAIN_BRANCH"
@@ -473,6 +508,7 @@ do
                             if [[ "$INPUT_VERBOSE" == true ]]; then
                                 echo "Create the security PR dependabot/clojure${cljdir/$GITHUB_WORKSPACE}/$escapedName-$latestVersion-$1-$time"
                             fi
+                            close_outdated_pr "$name" "$version" "$latestVersion"
                             update_package "$cljdir" "$name" "$1" "$escapedName" "$latestVersion" "$time" "$version" "$changesUrl" "$securityUpdatesPrBody"
                         fi
                     fi
@@ -480,7 +516,7 @@ do
             fi
         fi
     done
-    if [[ "$summaryOutput" -eq 1 ]]; then
+    if [[ "$summaryOutput" -eq 1 ]] && [[ "$INPUT_SUMMARY" == true ]]; then
         echo "</details>" >> "$GITHUB_STEP_SUMMARY"
         echo "" >> "$GITHUB_STEP_SUMMARY"
     fi

--- a/antq.sh
+++ b/antq.sh
@@ -31,7 +31,7 @@ version_lt() {
 }
 
 close_outdated_pr() {
-    existingPrs=$(gh pr list --state open --json title,number | jq -c '.[]')
+    existingPrs=$(gh pr list --state open --limit 1000 --json title,number | jq -c '.[]')
     if [[ "$INPUT_VERBOSE" == true ]]; then
         echo "Existing PRs: ${existingPrs}"
     fi

--- a/antq.sh
+++ b/antq.sh
@@ -30,14 +30,11 @@ version_lt() {
     test "$(echo "$@" | tr " " "\n" | sort -V | head -n 1)" == "$1"; 
 }
 
-# Define the function to close outdated PRs when a new update is available
 close_outdated_pr() {
     existingPrs=$(gh pr list --state open --json title,number | jq -c '.[]')
     if [[ "$INPUT_VERBOSE" == true ]]; then
         echo "Existing PRs: ${existingPrs}"
     fi
-    
-    # Use process substitution to pass the JSON objects directly to the while loop
     while IFS= read -r pr; do
         prTitle=$(echo "$pr" | jq -r '.title')
         prNumber=$(echo "$pr" | jq -r '.number')

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,15 +21,19 @@ if [[ "$INPUT_VERBOSE" == true ]]; then
 fi
 chmod +x /dependabot_alerts.sh
 /dependabot_alerts.sh
-if [[ "$INPUT_VERBOSE" == true ]]; then
+if [[ "$INPUT_VERBOSE" == true ]] && [[ "$INPUT_SUMMARY" == true ]]; then
     echo "Running alerts_summary.sh"
 fi
 chmod +x /alerts_summary.sh
-/alerts_summary.sh project.clj
-/alerts_summary.sh deps.edn
+if [[ "$INPUT_SUMMARY" == true ]]; then
+    /alerts_summary.sh project.clj
+    /alerts_summary.sh deps.edn
+fi
 if [[ "$INPUT_VERBOSE" == true ]]; then
     echo "Running antq.sh"
 fi
 chmod +x /antq.sh
 /antq.sh project.clj
 /antq.sh deps.edn
+git checkout "$INPUT_MAIN_BRANCH"
+git restore .


### PR DESCRIPTION
This PR introduces some improvements:

- If Dependabot finds a newer version of a package, it checks if outdated pull requests exist and closes them before opening the new one.
- `summary` boolean value allows enabling or disabling step markdown summary.