### PR TITLE
Fix broken correlator

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,2 @@
-.git
 test
+git-commit-hash

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM clojure:lein-trixie-slim
+FROM clojure:lein-trixie-slim AS base
 
 LABEL com.github.actions.name="Dependabot for Clojure projects" \
       com.github.actions.description="Run Dependabot as GitHub Action workflow in your Clojure project."

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ jobs:
           directory: "foo/bar"
 ```
 
-See [`actions.yml`](./actions.yml) for more details on each option.
+See [`action.yml`](./action.yml) for more details on each option.
 
 ## Development
 

--- a/clojure_dependabot.clj
+++ b/clojure_dependabot.clj
@@ -234,12 +234,13 @@
      (filter opts-post-filter)
      (into (github-vars))))
 
-;; Unsafe decision to fix https://github.com/actions/runner/issues/2033
 (defn- configure-git [github-workspace]
-  (log "Configuring git")
-  (sh "git" "config" "--global" "--add" "safe.directory" github-workspace)
-  (sh "git" "config" "--global" "user.email" "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com")
-  (sh "git" "config" "--global" "user.name" "github-actions[bot]"))
+  (when-not (System/getenv "LOCAL_DEV")
+    (log "Configuring git")
+    (sh "git" "config" "--global" "user.email" "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com")
+    (sh "git" "config" "--global" "user.name" "github-actions[bot]")
+    ;; Unsafe decision to fix https://github.com/actions/runner/issues/2033
+    (sh "git" "config" "--global" "--add" "safe.directory" github-workspace)))
 
 (defn- install-local-dependencies [{:keys [local-dependencies directory]
                                     :or {local-dependencies ""}}]

--- a/clojure_dependabot.clj
+++ b/clojure_dependabot.clj
@@ -15,6 +15,13 @@
 
 (s/check-asserts true)
 
+(def homepage
+  "https://github.com/pitch-io/clojure-dependabot")
+
+(def version
+  ;; TODO figure out a versioning/release scheme somehow
+  "unversioned")
+
 (def severities
   {"critical" 4
    "high" 3
@@ -302,7 +309,11 @@
             "--branch-ref" github-ref
             "--sha" github-sha
             "--directory" (fs/parent full-path)
-            "--job-name" "clojure-dependabot")))))
+            "--snapshot-exclude-file-name"
+            "--detector-name" "clojure-dependabot"
+            "--detector-url" homepage
+            "--detector-version" version
+            "--job-name" project-path)))))
 
 (defn gh-api-dependabot-alerts
   [{:keys [github-repository github-pat severity]}]

--- a/scripts/local.sh
+++ b/scripts/local.sh
@@ -23,4 +23,6 @@ export INPUT_REVIEWERS="${INPUT_REVIEWERS:-}"
 export INPUT_SECURITY_UPDATES_ONLY="${INPUT_SECURITY_UPDATES_ONLY:-false}"
 export INPUT_SEVERITY="${INPUT_SEVERITY:-low}"
 
+export LOCAL_DEV='1'
+
 exec bb clojure_dependabot.clj "$@"

--- a/scripts/local.sh
+++ b/scripts/local.sh
@@ -25,4 +25,6 @@ export INPUT_SEVERITY="${INPUT_SEVERITY:-low}"
 
 export LOCAL_DEV='1'
 
+git rev-parse HEAD > git-commit-hash
+
 exec bb clojure_dependabot.clj "$@"


### PR DESCRIPTION
Set the job name (which is used for the correlator) to the project path so the unique pairing of detector and correlator so we can make many submissions to the API which will merge these into a single dependency graph for the repo.

Ref: https://docs.github.com/en/rest/dependency-graph/dependency-submission?apiVersion=2022-11-28#create-a-snapshot-of-dependencies-for-a-repository